### PR TITLE
 feat: add health check to redis & mysql to prevent backend fails to …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
       - queue:/data
     networks:
       - gorya
-
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      timeout: 20s
+      retries: 10
   mysql:
     image: mysql
     container_name: mysql
@@ -24,6 +27,10 @@ services:
       - ./seeds/init.sql:/data/application/init.sql
     networks:
       - gorya
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
 
   gorya-backend:
 #    image: ghcr.io/nduyphuong/gorya-backend
@@ -40,8 +47,10 @@ services:
       GORYA_REDIS_ADDR: redis:6379
       GORYA_QUEUE_NAME: gorya
     depends_on:
-      - redis
-      - mysql
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
     networks:
       - gorya
 


### PR DESCRIPTION
…start

without health check, backend may fail to start if mysql container is not up and running yet